### PR TITLE
[feat/user/#7] : 사용자 관리 및 인증 기능 개발 (관리자용) 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ dependencies {
 	implementation 'org.springframework.security:spring-security-crypto'
 
 	// Lombok (코드 축약용 애노테이션)
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
+	compileOnly 'org.projectlombok:lombok:1.18.32'
+	annotationProcessor 'org.projectlombok:lombok:1.18.32'
 
 	// MapStruct (DTO ↔ Entity 자동 매핑)
 	implementation 'org.mapstruct:mapstruct:1.6.3'

--- a/src/main/java/com/kkimjinoh/global/config/PasswordConfig.java
+++ b/src/main/java/com/kkimjinoh/global/config/PasswordConfig.java
@@ -1,0 +1,14 @@
+package com.kkimjinoh.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/kkimjinoh/global/config/SecurityConfig.java
+++ b/src/main/java/com/kkimjinoh/global/config/SecurityConfig.java
@@ -1,0 +1,73 @@
+package com.kkimjinoh.global.config;
+
+import com.kkimjinoh.global.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .sessionManagement(session -> session.disable())
+                .authorizeHttpRequests(auth -> auth
+                        // 1. 일부 엔드포인트는 허용
+                        .requestMatchers(
+                                "/api/admin/auth/login",
+                                "/api/admin/auth/verify-code",
+                                "/api/admin/auth/reissue",
+                                "/auth/register",
+                                "/auth/verify",
+                                "/swagger-ui/**",
+                                "/api-docs/**",
+                                "/v3/api-docs/**"
+                        ).permitAll()
+
+                        // 2. 관리자 API는 인증 필요
+                        .requestMatchers("/api/admin/**").authenticated()
+
+                        // 3. 그 외 일반 API는 모두 허용
+                        .requestMatchers("/api/**").permitAll()
+
+                        // 4. 그 외 나머지는 인증 필요
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+
+    // 권한 계층 구조 설정 추가
+    @Bean
+    public RoleHierarchy roleHierarchy() {
+        RoleHierarchyImpl roleHierarchy = new RoleHierarchyImpl();
+        // 역할 계층 설정: ADMIN > MANAGER > OPERATOR
+        roleHierarchy.setHierarchy(
+                "ROLE_ADMIN > ROLE_MANAGER \nROLE_MANAGER > ROLE_OPERATOR"
+        );
+        return roleHierarchy;
+    }
+
+}

--- a/src/main/java/com/kkimjinoh/global/config/SwaggerMovieAdminConfig.java
+++ b/src/main/java/com/kkimjinoh/global/config/SwaggerMovieAdminConfig.java
@@ -1,7 +1,10 @@
 package com.kkimjinoh.global.config;
 
-import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.Components;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -12,13 +15,25 @@ import org.springframework.context.annotation.Profile;
 @Configuration
 @Profile("movieadmin")
 public class SwaggerMovieAdminConfig {
+
     @Bean
     public OpenAPI openAdminAPI() {
-        return new OpenAPI().info(new Info()
-                .title("🛠️ Movie Admin API")
-                .version("v2.0")
-                .description("관리자용 Swagger 명세입니다. <br>" +
-                        "👉 <a href='http://localhost:8080/api-docs' target='_blank'>사용자 Swagger 보기</a>")
-        );
+        final String securitySchemeName = "JWT";
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("🛠️ Movie Admin API")
+                        .version("v2.0")
+                        .description("관리자용 Swagger 명세입니다. <br>" +
+                                "👉 <a href='http://localhost:8080/api-docs' target='_blank'>사용자 Swagger 보기</a>")
+                )
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName, new SecurityScheme()
+                                .name(securitySchemeName)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
     }
+
 }

--- a/src/main/java/com/kkimjinoh/global/entity/DateEntity.java
+++ b/src/main/java/com/kkimjinoh/global/entity/DateEntity.java
@@ -7,19 +7,17 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import java.time.LocalDateTime;
 
 /**
  * 공통 일자(생성·수정·삭제) 컬럼을 갖는 베이스 엔티티
  */
-@Getter @Setter
-@SuperBuilder
+@Getter
+@SuperBuilder(toBuilder = true)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
@@ -43,4 +41,14 @@ public abstract class DateEntity {
             columnDefinition = "datetime comment '삭제일시'")
     @Schema(description = "삭제일시", example = "2025-06-01T20:00:00", nullable = true)
     private LocalDateTime deletedAt;
+
+    // 소프트 삭제 처리
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    // 복원(undo delete)
+    public void restore() {
+        this.deletedAt = null;
+    }
 }

--- a/src/main/java/com/kkimjinoh/global/error/DomainError.java
+++ b/src/main/java/com/kkimjinoh/global/error/DomainError.java
@@ -22,8 +22,20 @@ public enum DomainError implements ErrorModel {
     NOTICE_NOT_FOUND (400, "NOTICE_NOT_FOUND", "해당 공지사항을 찾을 수 없습니다"),
 
     // 사용자 그룹 에러
-    USER_GROUP_NOT_FOUND (400, "USER_GROUP_NOT_FOUND", "해당 사용자 그룹을 찾을 수 없습니다");
+    USER_GROUP_NOT_FOUND (400, "USER_GROUP_NOT_FOUND", "해당 사용자 그룹을 찾을 수 없습니다"),
 
+    // 사용자 에러
+    USER_NOT_FOUND (400, "USER_NOT_FOUND", "해당 사용자를 찾을 수 없습니다"),
+    INVALID_PASSWORD (400, "INVALID_PASSWORD", "비밀번호가 틀렸습니다"),
+    INVALID_TOKEN (401, "INVALID_TOKEN", "유효하지 않은 토큰입니다"),
+    ACCESS_DENIED (403, "ACCESS_DENIED", "접근 권한이 없습니다"),
+    USER_ALREADY_INVITED (400, "USER_ALREADY_INVITED", "이미 초대된(등록된) 사용자입니다"),
+
+    // AUTH 에러
+    INVALID_AUTH_CODE (400, "INVALID_AUTH_CODE", "인증코드가 틀렸습니다"),
+    AUTH_CODE_EXPIRED (400, "AUTH_CODE_EXPIRED", "인증코드가 만료되었습니다"),
+    INVALID_SIGNUP_TOKEN (400, "INVALID_SIGNUP_TOKEN", "유효하지 않은 회원가입 토큰입니다"),
+    SIGNUP_TOKEN_EXPIRED (400, "SIGNUP_TOKEN_EXPIRED", "회원가입 인증이 만료되었습니다");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/kkimjinoh/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kkimjinoh/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,37 @@
+package com.kkimjinoh.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String token = jwtTokenProvider.resolveToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/kkimjinoh/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/kkimjinoh/global/security/JwtTokenProvider.java
@@ -1,0 +1,124 @@
+package com.kkimjinoh.global.security;
+
+import com.kkimjinoh.movieadmin.domain.user.entity.UserEntity;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.*;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.*;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    private final Key key;
+    private final long accessTokenExpiration;
+    private final long refreshTokenExpiration;
+    private final long signupTokenExpiration;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-token-expiration}") long accessTokenExpiration,
+            @Value("${jwt.refresh-token-expiration}") long refreshTokenExpiration,
+            @Value("${jwt.signup-token-expiration}") long signupTokenExpiration
+    ) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+        this.accessTokenExpiration = accessTokenExpiration;
+        this.refreshTokenExpiration = refreshTokenExpiration;
+        this.signupTokenExpiration = signupTokenExpiration;
+    }
+
+    /** Access Token 발급 */
+    public String createAccessToken(UserEntity user) {
+        return createUserToken(user, accessTokenExpiration, "access");
+    }
+
+    /** Refresh Token 발급 */
+    public String createRefreshToken(UserEntity user) {
+        return createUserToken(user, refreshTokenExpiration, "refresh");
+    }
+
+    /** 회원가입용 SignupToken 발급 */
+    public String createSignupToken(UserEntity user) {
+        Claims claims = Jwts.claims().setSubject(user.getEmail());
+        claims.put("purpose", "signup");
+        claims.put("email", user.getEmail());
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + signupTokenExpiration);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /** 사용자 토큰 생성 */
+    private String createUserToken(UserEntity user, long expiration, String purpose) {
+        Claims claims = Jwts.claims().setSubject(user.getEmail());
+        claims.put("userId", user.getId());
+        claims.put("role", user.getUserRole().name());
+        claims.put("purpose", purpose);
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expiration);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /** 인증 객체 생성 */
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseClaims(token);
+        String email = claims.getSubject();
+        String role = (String) claims.get("role");
+
+        return new UsernamePasswordAuthenticationToken(
+                email,
+                null,
+                role != null ? Collections.singletonList(new SimpleGrantedAuthority(role)) : Collections.emptyList()
+        );
+    }
+
+    /** Authorization 헤더에서 토큰 추출 */
+    public String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        if (bearer != null && bearer.startsWith("Bearer ")) {
+            return bearer.substring(7);
+        }
+        return null;
+    }
+
+    /** JWT 유효성 검증 */
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            log.warn("JWT expired: {}", e.getMessage());
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn("Invalid JWT: {}", e.getMessage());
+        }
+        return false;
+    }
+
+    /** JWT Claims 파싱 */
+    public Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/java/com/kkimjinoh/global/util/CodeGenerator.java
+++ b/src/main/java/com/kkimjinoh/global/util/CodeGenerator.java
@@ -1,0 +1,12 @@
+package com.kkimjinoh.global.util;
+
+import java.util.UUID;
+
+public class CodeGenerator {
+
+    public static String generateRandomCode(int length) {
+        return UUID.randomUUID().toString().replace("-", "")
+                .substring(0, length).toUpperCase();
+    }
+
+}

--- a/src/main/java/com/kkimjinoh/movie/domain/community/service/CommunityService.java
+++ b/src/main/java/com/kkimjinoh/movie/domain/community/service/CommunityService.java
@@ -53,7 +53,6 @@ public class CommunityService {
      *
      * @param id   삭제 대상 게시글의 고유 ID
      * @param body 삭제용 비밀번호
-     * @return StatusOkResponseDto 성공(OK) 응답
      */
     @Transactional
     public void deleteMessage(Long id, RequestDeleteMessageDto body) {

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/auth/controller/AdminAuthController.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/auth/controller/AdminAuthController.java
@@ -1,0 +1,34 @@
+package com.kkimjinoh.movieadmin.domain.auth.controller;
+
+import com.kkimjinoh.movieadmin.domain.auth.docs.*;
+import com.kkimjinoh.movieadmin.domain.auth.dto.request.*;
+import com.kkimjinoh.movieadmin.domain.auth.dto.response.*;
+import com.kkimjinoh.movieadmin.domain.auth.service.AdminAuthService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 사용자 인증 관련 API 컨트롤러 (Admin 전용)
+ */
+@RestController
+@RequestMapping("/api/admin/auth")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ROLE_ADMIN')")
+@Tag(name = "사용자 인증", description = "인증 API")
+public class AdminAuthController {
+    private final AdminAuthService AdminauthService;
+
+    /**
+     * 새로운 사용자 초대 및 등록 (관리자)
+     */
+    @PostMapping("/invite")
+    @InviteDoc
+    public ResponseEntity<ResponseInviteDto> invite(@Valid @RequestBody RequestInviteDto body) {
+        return ResponseEntity.ok(AdminauthService.invite(body));
+    }
+
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/auth/controller/AuthController.java
@@ -1,0 +1,65 @@
+package com.kkimjinoh.movieadmin.domain.auth.controller;
+
+import com.kkimjinoh.global.dto.StatusOkResponseDto;
+import com.kkimjinoh.movieadmin.domain.auth.docs.*;
+import com.kkimjinoh.movieadmin.domain.auth.dto.request.*;
+import com.kkimjinoh.movieadmin.domain.auth.dto.response.*;
+import com.kkimjinoh.movieadmin.domain.auth.service.AuthService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 사용자 인증 관련 API 컨트롤러
+ */
+@RestController
+@RequestMapping("api/manager/auth")
+@RequiredArgsConstructor
+@Tag(name = "사용자 인증", description = "인증 API")
+public class AuthController {
+
+    private final AuthService authService;
+
+    /**
+     * 로그인 요청
+     */
+    @PostMapping("/login")
+    @LoginDoc
+    public ResponseEntity<ResponseLoginDto> login(@Valid @RequestBody RequestLoginDto body) {
+        ResponseLoginDto response = authService.login(body);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 회원가입 정보 입력 및 최종 등록
+     */
+    @PutMapping("/register")
+    @RegisterDoc
+    public ResponseEntity<StatusOkResponseDto> register(@Valid @RequestBody RequestRegisterDto body) {
+        StatusOkResponseDto response = authService.register(body);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 토큰 재발급 요청
+     */
+    @PostMapping("/reissue")
+    @ReissueDoc
+    public ResponseEntity<ResponseReissueDto> reissue(@Valid @RequestBody RequestReissueDto body) {
+        ResponseReissueDto response = authService.reissue(body.getAccessToken(), body.getRefreshToken());
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 토큰 재발급 요청
+     */
+    @PostMapping("/verify-code")
+    @VerifyCodeDoc
+    public ResponseEntity<ResponseVerifyCodeDto> verifyCode(@Valid @RequestBody RequestVerifyCodeDto body) {
+        ResponseVerifyCodeDto response = authService.verifyCode(body);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/auth/docs/InviteDoc.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/auth/docs/InviteDoc.java
@@ -1,0 +1,82 @@
+package com.kkimjinoh.movieadmin.domain.auth.docs;
+
+import com.kkimjinoh.global.dto.ErrorResponseDto;
+import com.kkimjinoh.movieadmin.domain.auth.dto.request.RequestInviteDto;
+import com.kkimjinoh.movieadmin.domain.auth.dto.response.ResponseInviteDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target(METHOD)
+@Retention(RUNTIME)
+@Documented
+@Operation(
+        summary = "\uD83D\uDD11 새로운 사용자 초대 및 등록 ",
+        description = "Admin(관리자) 권한을 가진 사용자가 새로운 사용자를 초대 및 등록한다."
+)
+@RequestBody(
+        required = true,
+        content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = RequestInviteDto.class)
+        )
+)
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "사용자 초대(등록) 정보 반환",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ResponseInviteDto.class)
+                )
+        ),
+        @ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (존재하지 않는 사용자 그룹, 이미 초대된 사용자, 존재하지 않는 관리자 등)",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponseDto.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "존재하지 않는 사용자 그룹",
+                                        value = "{\n  \"status\": 400,\n  \"code\": \"USER_GROUP_NOT_FOUND\",\n  \"message\": \"해당 사용자 그룹을 찾을 수 없습니다\"\n}"
+                                ),
+                                @ExampleObject(
+                                        name = "이미 초대된 사용자",
+                                        value = "{\n  \"status\": 400,\n  \"code\": \"USER_ALREADY_INVITED\",\n  \"message\": \"이미 초대된(등록된) 사용자입니다\"\n}"
+                                ),
+                                @ExampleObject(
+                                        name = "존재하지 않는 관리자",
+                                        value = "{\n  \"status\": 400,\n  \"code\": \"USER_NOT_FOUND\",\n  \"message\": \"해당 사용자를 찾을 수 없습니다\"\n}"
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(
+                responseCode = "403",
+                description = "접근 권한이 없는 경우",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponseDto.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "접근 거부",
+                                        value = "{\n  \"status\": 403,\n  \"code\": \"ACCESS_DENIED\",\n  \"message\": \"접근 권한이 없습니다\"\n}"
+                                )
+                        }
+                )
+        )
+
+})
+public @interface InviteDoc {}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/auth/docs/LoginDoc.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/auth/docs/LoginDoc.java
@@ -1,0 +1,79 @@
+package com.kkimjinoh.movieadmin.domain.auth.docs;
+
+import com.kkimjinoh.global.dto.ErrorResponseDto;
+import com.kkimjinoh.movieadmin.domain.auth.dto.request.RequestLoginDto;
+import com.kkimjinoh.movieadmin.domain.auth.dto.response.ResponseLoginDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target(METHOD)
+@Retention(RUNTIME)
+@Documented
+@SecurityRequirements
+@Operation(
+        summary = "사용자 로그인",
+        description = "이메일과 비밀번호로 로그인합니다."
+)
+@RequestBody(
+        required = true,
+        content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = RequestLoginDto.class)
+        )
+)
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "로그인 성공 (Access/Refresh 토큰 및 사용자 정보 반환)",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ResponseLoginDto.class)
+                )
+        ),
+        @ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (존재하지 않는 사용자, 비밀번호 불일치 등)",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponseDto.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "존재하지 않는 사용자",
+                                        value = "{\n  \"status\": 400,\n  \"code\": \"USER_NOT_FOUND\",\n  \"message\": \"해당 사용자를 찾을 수 없습니다\"\n}"
+                                ),
+                                @ExampleObject(
+                                        name = "비밀번호 불일치",
+                                        value = "{\n  \"status\": 400,\n  \"code\": \"INVALID_PASSWORD\",\n  \"message\": \"비밀번호가 틀렸습니다\"\n}"
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(
+                responseCode = "403",
+                description = "접근 권한이 없는 경우",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponseDto.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "접근 거부",
+                                        value = "{\n  \"status\": 403,\n  \"code\": \"ACCESS_DENIED\",\n  \"message\": \"접근 권한이 없습니다\"\n}"
+                                )
+                        }
+                )
+        )
+})
+public @interface LoginDoc {}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/auth/docs/RegisterDoc.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/auth/docs/RegisterDoc.java
@@ -1,0 +1,67 @@
+package com.kkimjinoh.movieadmin.domain.auth.docs;
+
+import com.kkimjinoh.global.dto.ErrorResponseDto;
+import com.kkimjinoh.global.dto.StatusOkResponseDto;
+import com.kkimjinoh.movieadmin.domain.auth.dto.request.RequestRegisterDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target(METHOD)
+@Retention(RUNTIME)
+@Documented
+@Operation(
+        summary = "회원가입 정보 입력 및 최종 등록",
+        description = "signupToken을 포함하여 회원가입 정보를 입력하고 회원 정보를 최종 등록합니다."
+)
+@RequestBody(
+        required = true,
+        content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = RequestRegisterDto.class)
+        )
+)
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "회원가입 성공",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = StatusOkResponseDto.class)
+                )
+        ),
+        @ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (회원가입 토큰 만료, 유효하지 않은 토큰, 사용자 미존재 등)",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponseDto.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "회원가입 토큰 만료",
+                                        value = "{\n  \"status\": 400,\n  \"code\": \"SIGNUP_TOKEN_EXPIRED\",\n  \"message\": \"회원가입 인증이 만료되었습니다\"\n}"
+                                ),
+                                @ExampleObject(
+                                        name = "유효하지 않은 회원가입 토큰",
+                                        value = "{\n  \"status\": 400,\n  \"code\": \"INVALID_SIGNUP_TOKEN\",\n  \"message\": \"유효하지 않은 회원가입 토큰입니다\"\n}"
+                                ),
+                                @ExampleObject(
+                                        name = "존재하지 않는 사용자",
+                                        value = "{\n  \"status\": 400,\n  \"code\": \"USER_NOT_FOUND\",\n  \"message\": \"해당 사용자를 찾을 수 없습니다\"\n}"
+                                )
+                        }
+                )
+        )
+})
+public @interface RegisterDoc {}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/auth/docs/ReissueDoc.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/auth/docs/ReissueDoc.java
@@ -1,64 +1,65 @@
-package com.kkimjinoh.movieadmin.domain.userGroup.docs;
+package com.kkimjinoh.movieadmin.domain.auth.docs;
 
 import com.kkimjinoh.global.dto.ErrorResponseDto;
-import com.kkimjinoh.movieadmin.domain.userGroup.dto.request.RequestUpdateUserGroupDto;
-import com.kkimjinoh.movieadmin.domain.userGroup.dto.response.ResponseGetUserGroupDto;
+import com.kkimjinoh.movieadmin.domain.auth.dto.request.RequestReissueDto;
+import com.kkimjinoh.movieadmin.domain.auth.dto.response.ResponseReissueDto;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
+@SecurityRequirements
 @Operation(
-        summary = "\uD83D\uDD11 사용자 그룹 수정",
-        description = "Admin(관리자) 권한을 가진 사용자가 특정 ID의 사용자 그룹을 수정한다."
-)
-@Parameter(
-        name = "id",
-        required = true,
-        description = "수정할 사용자 그룹 ID",
-        example = "1"
+        summary = "토큰 재발급",
+        description = "기존 Access/Refresh 토큰으로 새로운 Access 토큰을 재발급합니다."
 )
 @RequestBody(
         required = true,
         content = @Content(
                 mediaType = "application/json",
-                schema = @Schema(implementation = RequestUpdateUserGroupDto.class)
+                schema = @Schema(implementation = RequestReissueDto.class)
         )
 )
 @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
-                description = "수정된 사용자 그룹 정보 반환",
+                description = "토큰 재발급 성공",
                 content = @Content(
                         mediaType = "application/json",
-                        schema = @Schema(implementation = ResponseGetUserGroupDto.class)
+                        schema = @Schema(implementation = ResponseReissueDto.class)
                 )
         ),
         @ApiResponse(
                 responseCode = "400",
-                description = "잘못된 입력 값",
+                description = "잘못된 요청 (유효하지 않은 토큰, 사용자 미존재 등)",
                 content = @Content(
                         mediaType = "application/json",
                         schema = @Schema(implementation = ErrorResponseDto.class),
                         examples = {
                                 @ExampleObject(
-                                        name = "존재하지 않는 사용자 그룹",
-                                        value = "{\n  \"status\": 400,\n  \"code\": \"USER_GROUP_NOT_FOUND\",\n  \"message\": \"해당 사용자 그룹을 찾을 수 없습니다\"\n}"
+                                        name = "유효하지 않은 토큰",
+                                        value = "{\n  \"status\": 401,\n  \"code\": \"INVALID_TOKEN\",\n  \"message\": \"유효하지 않은 토큰입니다\"\n}"
                                 ),
+                                @ExampleObject(
+                                        name = "존재하지 않는 사용자",
+                                        value = "{\n  \"status\": 400,\n  \"code\": \"USER_NOT_FOUND\",\n  \"message\": \"해당 사용자를 찾을 수 없습니다\"\n}"
+                                )
                         }
                 )
         )
 })
-public @interface UpdateUserGroupDoc {}
+public @interface ReissueDoc {}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/auth/docs/VerifyCodeDoc.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/auth/docs/VerifyCodeDoc.java
@@ -1,0 +1,69 @@
+package com.kkimjinoh.movieadmin.domain.auth.docs;
+
+import com.kkimjinoh.global.dto.ErrorResponseDto;
+import com.kkimjinoh.movieadmin.domain.auth.dto.request.RequestVerifyCodeDto;
+import com.kkimjinoh.movieadmin.domain.auth.dto.response.ResponseVerifyCodeDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target(METHOD)
+@Retention(RUNTIME)
+@Documented
+@SecurityRequirements
+@Operation(
+        summary = "인증코드 검증 및 signupToken 발급",
+        description = "이메일과 인증코드를 검증한 후, 회원가입에 사용할 signupToken(JWT)을 발급합니다."
+)
+@RequestBody(
+        required = true,
+        content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = RequestVerifyCodeDto.class)
+        )
+)
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "인증코드 검증 성공 (signupToken 포함)",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ResponseVerifyCodeDto.class)
+                )
+        ),
+        @ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (인증코드 만료, 인증코드 오류, 사용자 미존재 등)",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponseDto.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "인증코드 만료",
+                                        value = "{\n  \"status\": 400,\n  \"code\": \"AUTH_CODE_EXPIRED\",\n  \"message\": \"인증코드가 만료되었습니다\"\n}"
+                                ),
+                                @ExampleObject(
+                                        name = "잘못된 인증코드",
+                                        value = "{\n  \"status\": 400,\n  \"code\": \"INVALID_AUTH_CODE\",\n  \"message\": \"인증코드가 틀렸습니다\"\n}"
+                                ),
+                                @ExampleObject(
+                                        name = "존재하지 않는 사용자",
+                                        value = "{\n  \"status\": 400,\n  \"code\": \"USER_NOT_FOUND\",\n  \"message\": \"해당 사용자를 찾을 수 없습니다\"\n}"
+                                )
+                        }
+                )
+        )
+})
+public @interface VerifyCodeDoc {}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/auth/dto/request/RequestInviteDto.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/auth/dto/request/RequestInviteDto.java
@@ -1,0 +1,31 @@
+package com.kkimjinoh.movieadmin.domain.auth.dto.request;
+
+import com.kkimjinoh.movieadmin.domain.user.entity.UserRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+/**
+ * 사용자 초대 RequestDto
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "사용자 초대(등록) 요청 DTO")
+public class RequestInviteDto {
+
+    @Schema(description = "이메일", example = "example@hallym.ac.kr", required = true)
+    @NotBlank(message = "이메일은 비어 있을 수 없습니다.")
+    private String email;
+
+    @Schema(description = "사용자 역할", example = "ROLE_MANAGER", required = true)
+    @NotNull(message = "사용자 역할은 필수 입력 값입니다.")
+    private UserRole userRole;
+
+    @Schema(description = "소속 그룹 ID", example = "1", required = true)
+    @NotNull(message = "소속 그룹 ID는 필수 입력 값입니다.")
+    private Long userGroupId;
+}
+

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/auth/dto/request/RequestLoginDto.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/auth/dto/request/RequestLoginDto.java
@@ -1,0 +1,24 @@
+package com.kkimjinoh.movieadmin.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+/**
+ * 로그인 RequestDto
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "로그인 요청")
+public class RequestLoginDto {
+
+    @Schema(description = "이메일", example = "sunwoo11228@gmail.com")
+    @NotBlank(message = "이메일은 비어 있을 수 없습니다.")
+    private String email;
+
+    @Schema(description = "비밀번호", example = "admin1234")
+    @NotBlank(message = "비밀번호는 비어 있을 수 없습니다.")
+    private String password;
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/auth/dto/request/RequestRegisterDto.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/auth/dto/request/RequestRegisterDto.java
@@ -1,0 +1,42 @@
+package com.kkimjinoh.movieadmin.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+/**
+ * 사용자 초대 RequestDto
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "사용자 초대 요청")
+public class RequestRegisterDto {
+
+    @Schema(description = "회원가입 완료를 위한 임시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR...")
+    @NotBlank(message = "임시 토큰은 비어 있을 수 없습니다.")
+    private String signupToken;
+
+    @Schema(description = "비밀번호 (BCrypt 암호화)", example = "admin1234")
+    @NotBlank(message = "비밀번호는 비어 있을 수 없습니다.")
+    private String password;
+
+    @Schema(description = "이름", example = "홍길동")
+    @NotBlank(message = "이름은 비어 있을 수 없습니다.")
+    private String name;
+
+    @Schema(description = "학번", example = "202412345")
+    @NotBlank(message = "학번은 비어 있을 수 없습니다.")
+    private String studentNumber;
+
+    @Schema(description = "휴대폰 번호", example = "01012345678")
+    @NotBlank(message = "휴대폰 번호는 비어 있을 수 없습니다.")
+    private String phoneNumber;
+
+    @Schema(description = "개인정보 수집 동의 여부", example = "true")
+    private boolean privacyAgree;
+
+    @Schema(description = "푸시 알림 동의 여부", example = "false")
+    private boolean pushAgree;
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/auth/dto/request/RequestReissueDto.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/auth/dto/request/RequestReissueDto.java
@@ -1,0 +1,24 @@
+package com.kkimjinoh.movieadmin.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+/**
+ * Access 토큰 재발급 RequestDto
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "토큰 재발급 요청")
+public class RequestReissueDto {
+
+    @Schema(description = "Access 토큰(만료 가능)", example = "eyJhbGciOiJIUzI1NiIsInR...")
+    @NotBlank(message = "Access 토큰은 비어 있을 수 없습니다.")
+    private String accessToken;
+
+    @Schema(description = "Refresh 토큰", example = "eyJhbGciOiJIUzI1NiIsInR...")
+    @NotBlank(message = "Refresh 토큰은 비어 있을 수 없습니다.")
+    private String refreshToken;
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/auth/dto/request/RequestVerifyCodeDto.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/auth/dto/request/RequestVerifyCodeDto.java
@@ -1,0 +1,24 @@
+package com.kkimjinoh.movieadmin.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+/**
+ * 이메일 인증 확인 RequestDto
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "이메일 인증 확인 요청")
+public class RequestVerifyCodeDto {
+
+    @Schema(description = "이메일", example = "user@hallym.ac.kr")
+    @NotBlank(message = "이메일은 비어 있을 수 없습니다.")
+    private String email;
+
+    @Schema(description = "인증코드", example = "A1B2C3")
+    @NotBlank(message = "인증코드는 비어 있을 수 없습니다.")
+    private String code;
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/auth/dto/response/ResponseInviteDto.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/auth/dto/response/ResponseInviteDto.java
@@ -1,0 +1,28 @@
+package com.kkimjinoh.movieadmin.domain.auth.dto.response;
+
+import com.kkimjinoh.movieadmin.domain.user.entity.UserRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+/**
+ * 사용자 초대 ResponseDto
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "사용자 초대(등록) 응답 DTO")
+public class ResponseInviteDto {
+
+    @Schema(description = "사용자 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "이메일", example = "example@hallym.ac.kr")
+    private String email;
+
+    @Schema(description = "사용자 역할", example = "ROLE_MANAGER")
+    private UserRole userRole;
+
+    @Schema(description = "소속 그룹 ID", example = "1")
+    private Long userGroupId;
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/auth/dto/response/ResponseLoginDto.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/auth/dto/response/ResponseLoginDto.java
@@ -1,0 +1,34 @@
+package com.kkimjinoh.movieadmin.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 로그인 ResponseDto
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "로그인 응답")
+public class ResponseLoginDto {
+
+    @Schema(description = "JWT Access Token", example = "eyJhbGciOiJIUzI1NiIsInR...")
+    private String accessToken;
+
+    @Schema(description = "JWT Refresh Token", example = "eyJhbGciOiJIUzI1NiIsInR...")
+    private String refreshToken;
+
+    @Schema(description = "이메일", example = "example@hallym.ac.kr")
+    private String email;
+
+    @Schema(description = "사용자 이름", example = "홍길동")
+    private String name;
+
+    @Schema(description = "권한", example = "ROLE_MANAGER")
+    private String role;
+
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/auth/dto/response/ResponseReissueDto.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/auth/dto/response/ResponseReissueDto.java
@@ -1,0 +1,19 @@
+package com.kkimjinoh.movieadmin.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+/**
+ * Access 토큰 재발급 ResponseDto
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Access 토큰 재발급 응답 DTO")
+public class ResponseReissueDto {
+
+    @Schema(description = "Access 토큰(만료 가능)", example = "eyJhbGciOiJIUzI1NiIsInR...")
+    private String accessToken;
+
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/auth/dto/response/ResponseVerifyCodeDto.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/auth/dto/response/ResponseVerifyCodeDto.java
@@ -1,0 +1,22 @@
+package com.kkimjinoh.movieadmin.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+/**
+ * 이메일 인증 확인 ResponseDto
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "이메일 인증 확인 요청")
+public class ResponseVerifyCodeDto {
+
+    @Schema(description = "이메일", example = "user@hallym.ac.kr")
+    private String email;
+
+    @Schema(description = "회원가입 완료를 위한 임시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR...")
+    private String signupToken;
+
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/auth/entity/AuthCodeEntity.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/auth/entity/AuthCodeEntity.java
@@ -1,0 +1,42 @@
+package com.kkimjinoh.movieadmin.domain.auth.entity;
+
+import com.kkimjinoh.global.entity.DateEntity;
+import com.kkimjinoh.movieadmin.domain.user.entity.UserEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import java.time.LocalDateTime;
+
+/**
+ * 사용자 인증 코드 Entity
+ */
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_auth_code")
+public class AuthCodeEntity extends DateEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "인증 코드 ID", example = "1")
+    private Long id;
+
+    @Column(nullable = false)
+    @Schema(description = "가입할 사용자 이메일", example = "example@hallym.ac.kr")
+    private String email;
+
+    @Column(nullable = false)
+    @Schema(description = "발급된 인증 코드", example = "8A7D3F")
+    private String code;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by_user_id", nullable = false)
+    @Schema(description = "코드를 발급한 관리자")
+    private UserEntity createdByUserId;
+
+    @Column(nullable = false)
+    @Schema(description = "인증 코드 만료 시간", example = "2025-06-06T00:00:00")
+    private LocalDateTime expiredAt;
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/auth/mapper/AuthMapper.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/auth/mapper/AuthMapper.java
@@ -1,0 +1,69 @@
+package com.kkimjinoh.movieadmin.domain.auth.mapper;
+
+import com.kkimjinoh.movieadmin.domain.auth.dto.request.RequestInviteDto;
+import com.kkimjinoh.movieadmin.domain.auth.dto.request.RequestRegisterDto;
+import com.kkimjinoh.movieadmin.domain.auth.dto.response.*;
+import com.kkimjinoh.movieadmin.domain.auth.entity.AuthCodeEntity;
+import com.kkimjinoh.movieadmin.domain.user.entity.UserEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import java.time.LocalDateTime;
+
+
+/**
+ * 사용자 인증 관련 Mapper
+ */
+@Mapper(componentModel = "spring")
+public interface AuthMapper {
+
+    /**
+     * RequestCreateUserDto → UserEntity 변환
+     */
+    @Mapping(source = "userGroupId", target = "userGroupEntity.id")
+    UserEntity reqInviteDtoToUserEntity(RequestInviteDto requestInviteDto);
+
+    /**
+     * (email + code + admin + expiredAt) → AuthCodeEntity 변환
+     */
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdByUserId", source = "admin")
+    AuthCodeEntity toAuthCodeEntity(String email, String code, UserEntity admin, LocalDateTime expiredAt);
+
+    /**
+     * UserEntity → ResponseInviteDto 변환
+     */
+    @Mapping(source = "userGroupEntity.id", target = "userGroupId")
+    ResponseInviteDto userEntityToResInviteDto(UserEntity userEntity);
+
+    /**
+     * UserEntity + (Access 토큰, Refresh 토큰) → ResponseLoginDto 변환
+     */
+    ResponseLoginDto userEntityToResLoginDto(UserEntity user, String accessToken, String refreshToken);
+
+    /**
+     * Access 토큰 → ResponseReissueDto 변환
+     */
+    ResponseReissueDto toResReissueDto(String accessToken);
+
+    /**
+     * (email + signupToken) → ResponseVerifyCodeDto 변환
+     */
+    ResponseVerifyCodeDto toResponseVerifyCodeDto(String email, String signupToken);
+
+    /**
+     * UserEntity + RequestRegisterDto → UserEntity 변환 (toBuilder 방식)
+     */
+    default UserEntity ReqRegisterDtoToUserEntity(RequestRegisterDto requestRegisterDto,
+                                                  UserEntity userEntity,
+                                                  String encodedPassword) {
+        return userEntity.toBuilder()
+                .name(requestRegisterDto.getName())
+                .password(encodedPassword)
+                .studentNumber(requestRegisterDto.getStudentNumber())
+                .phoneNumber(requestRegisterDto.getPhoneNumber())
+                .privacyAgree(requestRegisterDto.isPrivacyAgree())
+                .pushAgree(requestRegisterDto.isPushAgree())
+                .build();
+    }
+
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/auth/repository/AuthCodeRepository.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/auth/repository/AuthCodeRepository.java
@@ -1,0 +1,21 @@
+package com.kkimjinoh.movieadmin.domain.auth.repository;
+
+import com.kkimjinoh.movieadmin.domain.auth.entity.AuthCodeEntity;
+import com.kkimjinoh.movieadmin.domain.user.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * 사용자 인증 코드 Repository
+ */
+@Repository
+public interface AuthCodeRepository extends JpaRepository<AuthCodeEntity, Long> {
+
+    /**
+     * 인증코드 값으로 인증코드 엔티티를 조회
+     */
+    Optional<AuthCodeEntity> findByCode(String code);
+
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/auth/service/AdminAuthService.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/auth/service/AdminAuthService.java
@@ -1,0 +1,78 @@
+package com.kkimjinoh.movieadmin.domain.auth.service;
+
+import com.kkimjinoh.global.error.DomainError;
+import com.kkimjinoh.global.exception.DomainException;
+import com.kkimjinoh.movieadmin.domain.auth.dto.request.RequestInviteDto;
+import com.kkimjinoh.movieadmin.domain.auth.dto.response.*;
+import com.kkimjinoh.movieadmin.domain.auth.entity.AuthCodeEntity;
+import com.kkimjinoh.movieadmin.domain.auth.mapper.AuthMapper;
+import com.kkimjinoh.movieadmin.domain.auth.repository.AuthCodeRepository;
+import com.kkimjinoh.movieadmin.domain.user.entity.UserEntity;
+import com.kkimjinoh.movieadmin.domain.user.repository.UserRepository;
+import com.kkimjinoh.movieadmin.domain.userGroup.repository.UserGroupRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import java.time.LocalDateTime;
+import static com.kkimjinoh.global.util.CodeGenerator.generateRandomCode;
+
+/**
+ * 관리자 인증 관련 서비스
+ *
+ * 회원 초대 등
+ * 인증 및 회원 관련 로직을 담당한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminAuthService {
+
+    private final AuthMapper authMapper;
+    private final UserRepository userRepository;
+    private final AuthCodeRepository authCodeRepository;
+    private final UserGroupRepository userGroupRepository;
+
+    /**
+     * 관리자가 새로운 사용자를 초대(등록)한다.
+     *
+     * @param body 초대 요청 DTO
+     * @return ResponseInviteDto 생성된 사용자 정보 DTO
+     */
+    @Transactional
+    public ResponseInviteDto invite(RequestInviteDto body) {
+
+        // 소속 그룹 검증
+        userGroupRepository.findById(body.getUserGroupId())
+                .orElseThrow(() -> new DomainException(DomainError.USER_GROUP_NOT_FOUND));
+
+        // 이미 해당 이메일이 등록(초대)된 사용자가 있는지 체크
+        if (userRepository.findByEmail(body.getEmail()).isPresent()) {
+            throw new DomainException(DomainError.USER_ALREADY_INVITED);
+        }
+
+        // 직접 Entity 생성 및 값 매핑
+        UserEntity entity = authMapper.reqInviteDtoToUserEntity(body);
+        UserEntity saved = userRepository.save(entity);
+
+        // 현재 로그인 관리자 구하기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UserEntity admin = userRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new DomainException(DomainError.USER_NOT_FOUND));
+
+        // 인증코드(초대코드) 생성 및 저장
+        String code = generateRandomCode(6);
+
+        // (email + code + admin + expiredAt) → AuthCodeEntity 변환
+        AuthCodeEntity authCode = authMapper.toAuthCodeEntity(saved.getEmail(), code, admin, LocalDateTime.now().plusDays(2));
+        authCodeRepository.save(authCode);
+
+        // 인증코드 로그 출력 (나중에 메일 발송으로 교체)
+        log.info("[초대 코드 발급] {} ({})", code, saved.getEmail());
+
+        // UserEntity → ResponseInviteDto 변환
+        return authMapper.userEntityToResInviteDto(saved);
+    }
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/auth/service/AuthService.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/auth/service/AuthService.java
@@ -1,0 +1,201 @@
+package com.kkimjinoh.movieadmin.domain.auth.service;
+
+import com.kkimjinoh.global.dto.StatusOkResponseDto;
+import com.kkimjinoh.global.error.DomainError;
+import com.kkimjinoh.global.exception.DomainException;
+import com.kkimjinoh.global.security.JwtTokenProvider;
+import com.kkimjinoh.movieadmin.domain.auth.dto.request.RequestLoginDto;
+import com.kkimjinoh.movieadmin.domain.auth.dto.request.RequestRegisterDto;
+import com.kkimjinoh.movieadmin.domain.auth.dto.request.RequestVerifyCodeDto;
+import com.kkimjinoh.movieadmin.domain.auth.dto.response.*;
+import com.kkimjinoh.movieadmin.domain.auth.entity.AuthCodeEntity;
+import com.kkimjinoh.movieadmin.domain.auth.mapper.AuthMapper;
+import com.kkimjinoh.movieadmin.domain.auth.repository.AuthCodeRepository;
+import com.kkimjinoh.movieadmin.domain.user.entity.UserEntity;
+import com.kkimjinoh.movieadmin.domain.user.repository.UserRepository;
+import com.kkimjinoh.movieadmin.domain.userGroup.repository.UserGroupRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import java.time.LocalDateTime;
+
+/**
+ * 사용자 인증 관련 서비스
+ *
+ * 회원 초대, 로그인, 토큰 재발급, 인증코드 검증, 회원가입 등
+ * 인증 및 회원 관련 로직을 담당한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final AuthMapper authMapper;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthCodeRepository authCodeRepository;
+
+    /**
+     * 사용자 로그인 처리
+     *
+     * @param body 로그인 요청 DTO
+     * @return ResponseLoginDto 로그인 응답 DTO
+     */
+    public ResponseLoginDto login(RequestLoginDto body) {
+
+        // 이메일로 사용자 조회 (존재하지 않으면 예외 발생)
+        UserEntity user = userRepository.findByEmail(body.getEmail())
+                .orElseThrow(() -> new DomainException(DomainError.USER_NOT_FOUND));
+
+        // 비밀번호 일치 여부 확인 (불일치 시 예외 발생)
+        if (!passwordEncoder.matches(body.getPassword(), user.getPassword())) {
+            throw new DomainException(DomainError.INVALID_PASSWORD);
+        }
+
+        // Spring Security 인증 상태 확인 (미인증 시 예외 발생)
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new DomainException(DomainError.ACCESS_DENIED);
+        }
+
+        // AccessToken, RefreshToken 생성
+        String accessToken = jwtTokenProvider.createAccessToken(user);
+        String refreshToken = jwtTokenProvider.createRefreshToken(user);
+
+        // UserEntity + (Access 토큰, Refresh 토큰) → ResponseLoginDto 변환
+        return authMapper.userEntityToResLoginDto(user,accessToken,refreshToken);
+    }
+
+    /**
+     * Access 토큰 재발급 처리
+     *
+     * @param accessToken  기존 accessToken
+     * @param refreshToken 기존 refreshToken
+     * @return ResponseReissueDto access 토큰 재발급 응답 DTO
+     */
+    public ResponseReissueDto reissue(String accessToken, String refreshToken) {
+
+        Claims accessClaims;
+        try {
+            // accessToken에서 Claims 추출 (만료된 토큰도 Claims는 파싱 가능)
+            accessClaims = jwtTokenProvider.parseClaims(accessToken);
+        } catch (ExpiredJwtException e) {
+            // 만료된 경우 Claims만 추출
+            accessClaims = e.getClaims();
+        } catch (JwtException e) {
+            // 변조/위조된 토큰은 예외 처리
+            throw new DomainException(DomainError.INVALID_TOKEN);
+        }
+
+        // refreshToken 유효성 검사 (유효하지 않으면 예외)
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new DomainException(DomainError.INVALID_TOKEN);
+        }
+
+        // Access/RefreshToken에서 이메일(사용자) 정보 추출
+        String emailFromAccess = accessClaims.getSubject();
+        Claims refreshClaims = jwtTokenProvider.parseClaims(refreshToken);
+        String emailFromRefresh = refreshClaims.getSubject();
+
+        // 두 토큰의 유저 정보가 일치하지 않으면 예외 처리
+        if (!emailFromAccess.equals(emailFromRefresh)) {
+            throw new DomainException(DomainError.INVALID_TOKEN);
+        }
+
+        // 해당 이메일의 유저 조회 (없으면 예외)
+        UserEntity user = userRepository.findByEmail(emailFromAccess)
+                .orElseThrow(() -> new DomainException(DomainError.USER_NOT_FOUND));
+
+        // 새로운 accessToken 생성
+        String newAccessToken = jwtTokenProvider.createAccessToken(user);
+
+        // 새로운 Access 토큰 → ResponseReissueDto 변환
+        return authMapper.toResReissueDto(newAccessToken);
+    }
+
+    /**
+     * 인증코드 검증(이메일/코드), soft delete 처리 및 signupToken 발급
+     *
+     * @param body 인증코드 검증 요청 DTO
+     * @return ResponseVerifyCodeDto 인증코드 검증 응답 DTO (signupToken 포함)
+     */
+    @Transactional
+    public ResponseVerifyCodeDto verifyCode(RequestVerifyCodeDto body) {
+
+        // 이메일로 유저 조회 (없으면 예외)
+        UserEntity user = userRepository.findByEmail(body.getEmail())
+                .orElseThrow(() -> new DomainException(DomainError.USER_NOT_FOUND));
+
+        // 인증코드로 코드 엔티티 조회 (없으면 예외)
+        AuthCodeEntity code = authCodeRepository.findByCode(body.getCode())
+                .orElseThrow(() -> new DomainException(DomainError.INVALID_AUTH_CODE));
+
+        // 인증코드 만료 여부 확인 및 soft delete 처리 (만료 시 예외)
+        if (code.getExpiredAt().isBefore(LocalDateTime.now())) {
+            code.softDelete();
+            authCodeRepository.save(code);
+            throw new DomainException(DomainError.AUTH_CODE_EXPIRED);
+        }
+
+        // 인증코드 사용 처리 (soft delete)
+        code.softDelete();
+        authCodeRepository.save(code);
+
+        // signupToken 발급
+        String signupToken = jwtTokenProvider.createSignupToken(user);
+
+        // (email + signupToken) → ResponseVerifyCodeDto 변환
+        return authMapper.toResponseVerifyCodeDto(user.getEmail(),signupToken);
+    }
+
+    /**
+     * 회원가입 정보 입력 및 최종 등록 (signupToken 검증)
+     *
+     * @param body 회원가입 요청 DTO
+     * @return StatusOkResponseDto 성공(OK) 응답
+     */
+    @Transactional
+    public StatusOkResponseDto register(RequestRegisterDto body) {
+
+        Claims claims;
+        try {
+            // signupToken 파싱 및 검증
+            claims = jwtTokenProvider.parseClaims(body.getSignupToken());
+        } catch (ExpiredJwtException e) {
+            // signupToken 만료 예외 처리
+            throw new DomainException(DomainError.SIGNUP_TOKEN_EXPIRED);
+        } catch (JwtException | IllegalArgumentException e) {
+            // signupToken 변조/오류 예외 처리
+            throw new DomainException(DomainError.INVALID_SIGNUP_TOKEN);
+        }
+
+        // 토큰 purpose 검증 (signup 목적만 허용)
+        if (!"signup".equals(claims.get("purpose"))) {
+            throw new DomainException(DomainError.INVALID_SIGNUP_TOKEN);
+        }
+        String email = claims.get("email", String.class);
+
+        // 유저 조회 (없으면 예외)
+        UserEntity user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new DomainException(DomainError.USER_NOT_FOUND));
+
+        // 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(body.getPassword());
+
+        // UserEntity + RequestRegisterDto  → UserEntity 변환
+        user = authMapper.ReqRegisterDtoToUserEntity(body, user, encodedPassword);
+        userRepository.save(user);
+
+        // OK 응답 반환
+        return new StatusOkResponseDto();
+    }
+
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/user/controller/AdminUserController.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/user/controller/AdminUserController.java
@@ -1,0 +1,52 @@
+package com.kkimjinoh.movieadmin.domain.user.controller;
+
+import com.kkimjinoh.global.dto.StatusOkResponseDto;
+import com.kkimjinoh.movieadmin.domain.user.docs.DeleteUserDoc;
+import com.kkimjinoh.movieadmin.domain.user.docs.GetUserDetailListDoc;
+import com.kkimjinoh.movieadmin.domain.user.docs.UpdateUserDoc;
+import com.kkimjinoh.movieadmin.domain.user.dto.request.RequestUpdateUserDto;
+import com.kkimjinoh.movieadmin.domain.user.dto.response.ResponseGetUserDetailDto;
+import com.kkimjinoh.movieadmin.domain.user.service.AdminUserService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 사용자 관련 API 컨트롤러 (Admin 전용)
+ */
+@RestController
+@RequestMapping("api/admin/user")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ROLE_ADMIN')")
+@Tag(name = "사용자", description = "사용자 관련 API")
+public class AdminUserController {
+
+    private final AdminUserService adminUserService;
+
+    @GetMapping("/all")
+    @GetUserDetailListDoc
+    public ResponseEntity<List<ResponseGetUserDetailDto>> getUserDetailList() {
+        return ResponseEntity.ok(adminUserService.getUserDetailList());
+    }
+
+    @PutMapping("/{id}")
+    @UpdateUserDoc
+    public ResponseEntity<ResponseGetUserDetailDto> updateUser(
+            @PathVariable Long id,
+            @Valid @RequestBody RequestUpdateUserDto body
+    ) {
+        return ResponseEntity.ok(adminUserService.updateUser(id, body));
+    }
+
+    @DeleteMapping("/{id}")
+    @DeleteUserDoc
+    public ResponseEntity<StatusOkResponseDto> deleteUser(@PathVariable Long id) {
+        return ResponseEntity.ok(adminUserService.deleteUser(id));
+    }
+
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/user/controller/UserController.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/user/controller/UserController.java
@@ -1,0 +1,55 @@
+package com.kkimjinoh.movieadmin.domain.user.controller;
+
+import com.kkimjinoh.global.dto.StatusOkResponseDto;
+import com.kkimjinoh.movieadmin.domain.user.docs.DeleteMyAccountDoc;
+import com.kkimjinoh.movieadmin.domain.user.docs.GetMyInfoDoc;
+import com.kkimjinoh.movieadmin.domain.user.docs.GetUserListDoc;
+import com.kkimjinoh.movieadmin.domain.user.docs.UpdateMyInfoDoc;
+import com.kkimjinoh.movieadmin.domain.user.dto.request.RequestUpdateMyInfoDto;
+import com.kkimjinoh.movieadmin.domain.user.dto.response.ResponseGetUserDetailDto;
+import com.kkimjinoh.movieadmin.domain.user.dto.response.ResponseGetUserDto;
+import com.kkimjinoh.movieadmin.domain.user.service.UserService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 사용자 관련 API 컨트롤러
+ */
+@RestController
+@RequestMapping("api/manager/user")
+@RequiredArgsConstructor
+@Tag(name = "사용자", description = "사용자 관련 API")
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/all")
+    @GetUserListDoc
+    public ResponseEntity<List<ResponseGetUserDto>> getUserList() {
+        return ResponseEntity.ok(userService.getUserList());
+    }
+
+    @GetMapping()
+    @GetMyInfoDoc
+    public ResponseEntity<ResponseGetUserDetailDto> getMyInfo() {
+        return ResponseEntity.ok(userService.getMyInfo());
+    }
+
+    @PutMapping()
+    @UpdateMyInfoDoc
+    public ResponseEntity<ResponseGetUserDetailDto> updateMyInfo(@Valid @RequestBody RequestUpdateMyInfoDto body) {
+        return ResponseEntity.ok(userService.updateMyInfo(body));
+    }
+
+    @DeleteMapping()
+    @DeleteMyAccountDoc
+    public ResponseEntity<StatusOkResponseDto> deleteMyAccount() {
+        return ResponseEntity.ok(userService.deleteMyAccount());
+    }
+
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/user/docs/DeleteMyAccountDoc.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/user/docs/DeleteMyAccountDoc.java
@@ -1,13 +1,11 @@
-package com.kkimjinoh.movieadmin.domain.lostitem.docs;
+package com.kkimjinoh.movieadmin.domain.user.docs;
 
-import com.kkimjinoh.global.dto.ErrorResponseDto;
 import com.kkimjinoh.global.dto.StatusOkResponseDto;
+import com.kkimjinoh.global.dto.ErrorResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
@@ -21,33 +19,27 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
-@Operation(
-        summary = "분실물 삭제",
-        description = "메시지 ID에 해당하는 커뮤니티 글을 비밀번호 검증을 후 삭제한다."
-)
-@Parameter(
-        name = "id",
-        required = true,
-        description = "삭제할 글 ID",
-        example = "1"
-)
+@Operation(summary = "내 계정 탈퇴", description = "현재 로그인된 사용자의 계정을 탈퇴 처리한다 (Soft Delete).")
 @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
-                description = "삭제 성공",
-                content = @Content(schema = @Schema(implementation = StatusOkResponseDto.class))
+                description = "탈퇴 성공",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = StatusOkResponseDto.class)
+                )
         ),
         @ApiResponse(
                 responseCode = "400",
-                description = "존재하지 않는 분실물",
+                description = "사용자 없음",
                 content = @Content(
                         mediaType = "application/json",
                         schema = @Schema(implementation = ErrorResponseDto.class),
                         examples = @ExampleObject(
-                                name = "분실물 없음",
-                                value = "{\n  \"status\": 400,\n  \"code\": \"LOST_ITEM_NOT_FOUND\",\n  \"message\": \"해당 분실물을 찾을 수 없습니다\"\n}"
+                                name = "USER_NOT_FOUND",
+                                value = "{\n  \"status\": 400,\n  \"code\": \"USER_NOT_FOUND\",\n  \"message\": \"해당 사용자를 찾을 수 없습니다\"\n}"
                         )
                 )
         )
 })
-public @interface DeleteLostItemDoc {}
+public @interface DeleteMyAccountDoc {}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/user/docs/DeleteUserDoc.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/user/docs/DeleteUserDoc.java
@@ -1,0 +1,60 @@
+package com.kkimjinoh.movieadmin.domain.user.docs;
+
+import com.kkimjinoh.global.dto.ErrorResponseDto;
+import com.kkimjinoh.global.dto.StatusOkResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target(METHOD)
+@Retention(RUNTIME)
+@Documented
+@Operation(
+        summary = "\uD83D\uDD11 특정 사용자 삭제",
+        description = "관리자가 사용자를 삭제한다."
+)
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "삭제 성공",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = StatusOkResponseDto.class)
+                )
+        ),
+        @ApiResponse(
+                responseCode = "400",
+                description = "존재하지 않는 사용자",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponseDto.class),
+                        examples = @ExampleObject(
+                                name = "사용자 없음",
+                                value = "{\n  \"status\": 400,\n  \"code\": \"USER_NOT_FOUND\",\n  \"message\": \"사용자를 찾을 수 없습니다\"\n}"
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "403",
+                description = "접근 권한 없음",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponseDto.class),
+                        examples = @ExampleObject(
+                                name = "접근 거부",
+                                value = "{\n  \"status\": 403,\n  \"code\": \"ACCESS_DENIED\",\n  \"message\": \"접근 권한이 없습니다\"\n}"
+                        )
+                )
+        )
+})
+public @interface DeleteUserDoc {}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/user/docs/GetMyInfoDoc.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/user/docs/GetMyInfoDoc.java
@@ -1,13 +1,11 @@
-package com.kkimjinoh.movieadmin.domain.lostitem.docs;
+package com.kkimjinoh.movieadmin.domain.user.docs;
 
 import com.kkimjinoh.global.dto.ErrorResponseDto;
-import com.kkimjinoh.global.dto.StatusOkResponseDto;
+import com.kkimjinoh.movieadmin.domain.user.dto.response.ResponseGetUserDetailDto;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
@@ -22,32 +20,29 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Documented
 @Operation(
-        summary = "분실물 삭제",
-        description = "메시지 ID에 해당하는 커뮤니티 글을 비밀번호 검증을 후 삭제한다."
-)
-@Parameter(
-        name = "id",
-        required = true,
-        description = "삭제할 글 ID",
-        example = "1"
+        summary = "내 정보 조회",
+        description = "현재 로그인된 사용자의 상세 정보를 조회한다."
 )
 @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
-                description = "삭제 성공",
-                content = @Content(schema = @Schema(implementation = StatusOkResponseDto.class))
+                description = "내 정보 반환",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ResponseGetUserDetailDto.class)
+                )
         ),
         @ApiResponse(
                 responseCode = "400",
-                description = "존재하지 않는 분실물",
+                description = "사용자 없음",
                 content = @Content(
                         mediaType = "application/json",
                         schema = @Schema(implementation = ErrorResponseDto.class),
                         examples = @ExampleObject(
-                                name = "분실물 없음",
-                                value = "{\n  \"status\": 400,\n  \"code\": \"LOST_ITEM_NOT_FOUND\",\n  \"message\": \"해당 분실물을 찾을 수 없습니다\"\n}"
+                                name = "USER_NOT_FOUND",
+                                value = "{\n  \"status\": 400,\n  \"code\": \"USER_NOT_FOUND\",\n  \"message\": \"해당 사용자를 찾을 수 없습니다\"\n}"
                         )
                 )
         )
 })
-public @interface DeleteLostItemDoc {}
+public @interface GetMyInfoDoc {}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/user/docs/GetUserDetailListDoc.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/user/docs/GetUserDetailListDoc.java
@@ -1,0 +1,60 @@
+package com.kkimjinoh.movieadmin.domain.user.docs;
+
+import com.kkimjinoh.global.dto.ErrorResponseDto;
+import com.kkimjinoh.movieadmin.domain.user.dto.response.ResponseGetUserDetailDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target(METHOD)
+@Retention(RUNTIME)
+@Documented
+@Operation(
+        summary = "\uD83D\uDD11 전체 사용자 목록 상세 조회",
+        description = "관리자가 모든 사용자의 상세 정보를 조회한다."
+)
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "사용자 목록 반환",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ResponseGetUserDetailDto.class)   // 배열로 표현됨
+                )
+        ),
+        @ApiResponse(
+                responseCode = "400",
+                description = "사용자가 하나도 존재하지 않을 때",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponseDto.class),
+                        examples = @ExampleObject(
+                                name = "사용자 없음",
+                                value = "{\n  \"status\": 400,\n  \"code\": \"USER_NOT_FOUND\",\n  \"message\": \"사용자를 찾을 수 없습니다\"\n}"
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "403",
+                description = "접근 권한 없음",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponseDto.class),
+                        examples = @ExampleObject(
+                                name = "접근 거부",
+                                value = "{\n  \"status\": 403,\n  \"code\": \"ACCESS_DENIED\",\n  \"message\": \"접근 권한이 없습니다\"\n}"
+                        )
+                )
+        )
+})
+public @interface GetUserDetailListDoc {}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/user/docs/GetUserListDoc.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/user/docs/GetUserListDoc.java
@@ -1,13 +1,11 @@
-package com.kkimjinoh.movieadmin.domain.lostitem.docs;
+package com.kkimjinoh.movieadmin.domain.user.docs;
 
 import com.kkimjinoh.global.dto.ErrorResponseDto;
-import com.kkimjinoh.global.dto.StatusOkResponseDto;
+import com.kkimjinoh.movieadmin.domain.user.dto.response.ResponseGetUserDto;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
@@ -22,32 +20,29 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Documented
 @Operation(
-        summary = "분실물 삭제",
-        description = "메시지 ID에 해당하는 커뮤니티 글을 비밀번호 검증을 후 삭제한다."
-)
-@Parameter(
-        name = "id",
-        required = true,
-        description = "삭제할 글 ID",
-        example = "1"
+        summary = "전체 사용자 목록 조회",
+        description = "시스템에 등록된 전체 사용자의 간략한 정보를 조회한다."
 )
 @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
-                description = "삭제 성공",
-                content = @Content(schema = @Schema(implementation = StatusOkResponseDto.class))
+                description = "사용자 목록 반환",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ResponseGetUserDto.class)
+                )
         ),
         @ApiResponse(
                 responseCode = "400",
-                description = "존재하지 않는 분실물",
+                description = "사용자 없음",
                 content = @Content(
                         mediaType = "application/json",
                         schema = @Schema(implementation = ErrorResponseDto.class),
                         examples = @ExampleObject(
-                                name = "분실물 없음",
-                                value = "{\n  \"status\": 400,\n  \"code\": \"LOST_ITEM_NOT_FOUND\",\n  \"message\": \"해당 분실물을 찾을 수 없습니다\"\n}"
+                                name = "USER_NOT_FOUND",
+                                value = "{\n  \"status\": 400,\n  \"code\": \"USER_NOT_FOUND\",\n  \"message\": \"해당 사용자를 찾을 수 없습니다\"\n}"
                         )
                 )
         )
 })
-public @interface DeleteLostItemDoc {}
+public @interface GetUserListDoc {}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/user/docs/UpdateMyInfoDoc.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/user/docs/UpdateMyInfoDoc.java
@@ -1,9 +1,9 @@
-package com.kkimjinoh.movieadmin.domain.lostitem.docs;
+package com.kkimjinoh.movieadmin.domain.user.docs;
 
 import com.kkimjinoh.global.dto.ErrorResponseDto;
-import com.kkimjinoh.global.dto.StatusOkResponseDto;
+import com.kkimjinoh.movieadmin.domain.user.dto.request.RequestUpdateMyInfoDto;
+import com.kkimjinoh.movieadmin.domain.user.dto.response.ResponseGetUserDetailDto;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -18,36 +18,41 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
 @Operation(
-        summary = "분실물 삭제",
-        description = "메시지 ID에 해당하는 커뮤니티 글을 비밀번호 검증을 후 삭제한다."
+        summary = "내 정보 수정",
+        description = "현재 로그인된 사용자의 정보를 수정한다."
 )
-@Parameter(
-        name = "id",
+@RequestBody(
         required = true,
-        description = "삭제할 글 ID",
-        example = "1"
+        content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = RequestUpdateMyInfoDto.class)
+        )
 )
 @ApiResponses({
         @ApiResponse(
                 responseCode = "200",
-                description = "삭제 성공",
-                content = @Content(schema = @Schema(implementation = StatusOkResponseDto.class))
+                description = "수정된 내 정보 반환",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ResponseGetUserDetailDto.class)
+                )
         ),
         @ApiResponse(
                 responseCode = "400",
-                description = "존재하지 않는 분실물",
+                description = "사용자 없음",
                 content = @Content(
                         mediaType = "application/json",
                         schema = @Schema(implementation = ErrorResponseDto.class),
                         examples = @ExampleObject(
-                                name = "분실물 없음",
-                                value = "{\n  \"status\": 400,\n  \"code\": \"LOST_ITEM_NOT_FOUND\",\n  \"message\": \"해당 분실물을 찾을 수 없습니다\"\n}"
+                                name = "USER_NOT_FOUND",
+                                value = "{\n  \"status\": 400,\n  \"code\": \"USER_NOT_FOUND\",\n  \"message\": \"해당 사용자를 찾을 수 없습니다\"\n}"
                         )
                 )
         )
 })
-public @interface DeleteLostItemDoc {}
+public @interface UpdateMyInfoDoc {}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/user/docs/UpdateUserDoc.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/user/docs/UpdateUserDoc.java
@@ -1,0 +1,69 @@
+package com.kkimjinoh.movieadmin.domain.user.docs;
+
+import com.kkimjinoh.global.dto.ErrorResponseDto;
+import com.kkimjinoh.movieadmin.domain.user.dto.request.RequestUpdateUserDto;
+import com.kkimjinoh.movieadmin.domain.user.dto.response.ResponseGetUserDetailDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target(METHOD)
+@Retention(RUNTIME)
+@Documented
+@Operation(
+        summary = "\uD83D\uDD11 특정 사용자 정보 수정",
+        description = "관리자가 특정 사용자의 정보를 수정한다."
+)
+@RequestBody(
+        required = true,
+        content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = RequestUpdateUserDto.class)
+        )
+)
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "수정된 사용자 정보 반환",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ResponseGetUserDetailDto.class)
+                )
+        ),
+        @ApiResponse(
+                responseCode = "400",
+                description = "존재하지 않는 사용자",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponseDto.class),
+                        examples = @ExampleObject(
+                                name = "사용자 없음",
+                                value = "{\n  \"status\": 400,\n  \"code\": \"USER_NOT_FOUND\",\n  \"message\": \"사용자를 찾을 수 없습니다\"\n}"
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "403",
+                description = "접근 권한 없음",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponseDto.class),
+                        examples = @ExampleObject(
+                                name = "접근 거부",
+                                value = "{\n  \"status\": 403,\n  \"code\": \"ACCESS_DENIED\",\n  \"message\": \"접근 권한이 없습니다\"\n}"
+                        )
+                )
+        )
+})
+public @interface UpdateUserDoc {}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/user/dto/request/RequestUpdateMyInfoDto.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/user/dto/request/RequestUpdateMyInfoDto.java
@@ -1,0 +1,39 @@
+package com.kkimjinoh.movieadmin.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+/**
+ * 내 정보 수정 요청 RequestDto
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "내 정보 수정 요청 DTO")
+public class RequestUpdateMyInfoDto {
+
+    @Schema(description = "이름", example = "홍길동")
+    @NotBlank
+    private String name;
+
+    @Schema(description = "전화번호", example = "010-1234-5678")
+    @NotBlank
+    private String phoneNumber;
+
+    @Schema(description = "학번", example = "202412345")
+    @NotBlank
+    private String studentNumber;
+
+    @Schema(description = "소속 그룹 ID", example = "1")
+    private Long userGroupId;
+
+    @Schema(description = "개인정보 수집 동의", example = "true")
+    private boolean privacyAgree;
+
+    @Schema(description = "알림 수신 동의", example = "true")
+    private boolean pushAgree;
+
+
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/user/dto/request/RequestUpdateUserDto.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/user/dto/request/RequestUpdateUserDto.java
@@ -1,0 +1,44 @@
+package com.kkimjinoh.movieadmin.domain.user.dto.request;
+
+import com.kkimjinoh.movieadmin.domain.user.entity.UserRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 사용자 정보 수정 요청 RequestDto
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "사용자 정보 수정 요청 DTO")
+public class RequestUpdateUserDto {
+
+    @Schema(description = "사용자 역할", example = "ROLE_MANAGER")
+    private UserRole userRole;
+
+    @Schema(description = "이름", example = "홍길동")
+    @NotBlank
+    private String name;
+
+    @Schema(description = "전화번호", example = "010-1234-5678")
+    @NotBlank
+    private String phoneNumber;
+
+    @Schema(description = "학번", example = "202412345")
+    @NotBlank
+    private String studentNumber;
+
+    @Schema(description = "소속 그룹 ID", example = "1")
+    private Long userGroupId;
+
+    @Schema(description = "개인정보 수집 동의", example = "true")
+    private boolean privacyAgree;
+
+    @Schema(description = "알림 수신 동의", example = "true")
+    private boolean pushAgree;
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/user/dto/response/ResponseGetUserDetailDto.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/user/dto/response/ResponseGetUserDetailDto.java
@@ -1,0 +1,36 @@
+package com.kkimjinoh.movieadmin.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+
+/**
+ * 사용자 상세 정보 ResponseDto
+ */
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "사용자 상세 조회 응답")
+public class ResponseGetUserDetailDto extends ResponseGetUserDto {
+
+    @Schema(description = "개인정보 수집 동의", example = "true")
+    private boolean privacyAgree;
+
+    @Schema(description = "알림 수신 동의", example = "true")
+    private boolean pushAgree;
+
+    @Schema(description = "최근 로그인 시각", example = "2025-06-05T21:00:00")
+    private LocalDateTime loginDate;
+
+    @Schema(description = "생성일시", example = "2025-06-01T20:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정일시", example = "2025-06-01T20:05:00")
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/user/dto/response/ResponseGetUserDto.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/user/dto/response/ResponseGetUserDto.java
@@ -1,0 +1,41 @@
+package com.kkimjinoh.movieadmin.domain.user.dto.response;
+
+import com.kkimjinoh.movieadmin.domain.user.entity.UserRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * 사용자 정보 ResponseDto
+ */
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "사용자 단일 조회 응답")
+public class ResponseGetUserDto {
+
+    @Schema(description = "사용자 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "이메일", example = "example@hallym.ac.kr")
+    private String email;
+
+    @Schema(description = "사용자 역할", example = "ROLE_MANAGER")
+    private UserRole userRole;
+
+    @Schema(description = "소속 그룹 ID", example = "1")
+    private Long userGroupId;
+
+    @Schema(description = "이름", example = "홍길동")
+    private String name;
+
+    @Schema(description = "학번", example = "202412345")
+    private String studentNumber;
+
+    @Schema(description = "전화번호", example = "010-1234-5678")
+    private String phoneNumber;
+
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/user/entity/UserEntity.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/user/entity/UserEntity.java
@@ -1,0 +1,71 @@
+package com.kkimjinoh.movieadmin.domain.user.entity;
+
+import com.kkimjinoh.global.entity.DateEntity;
+import com.kkimjinoh.movieadmin.domain.userGroup.entity.UserGroupEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.Where;
+
+import java.time.LocalDateTime;
+
+/**
+ * 사용자 Entity
+ */
+@Entity
+@Getter
+@SuperBuilder(toBuilder = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "deleted_at IS NULL")
+@Table(name = "user")
+public class UserEntity extends DateEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Schema(description = "사용자 ID", example = "1")
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    @Schema(description = "이메일", example = "example@hallym.ac.kr")
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Schema(description = "사용자 역할", example = "ROLE_MANAGER")
+    private UserRole userRole;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_group_id", nullable = false)
+    @Schema(description = "사용자 소속 그룹")
+    private UserGroupEntity userGroupEntity;
+
+    @Column(nullable = true)
+    @Schema(description = "이름", example = "홍길동")
+    private String name;
+
+    @Column(nullable = true)
+    @Schema(description = "비밀번호 (BCrypt 암호화)", example = "$2a$10$...")
+    private String password;
+
+    @Column(nullable = true)
+    @Schema(description = "학번", example = "202412345")
+    private String studentNumber;
+
+    @Column(nullable = true)
+    @Schema(description = "전화번호", example = "010-1234-5678")
+    private String phoneNumber;
+
+    @Column(nullable = false, columnDefinition = "boolean default false")
+    @Schema(description = "개인정보 수집 동의 여부", example = "true")
+    private boolean privacyAgree;
+
+    @Column(nullable = false, columnDefinition = "boolean default false")
+    @Schema(name = "pushAgree", description = "알림 수신 동의 여부", example = "true")
+    private boolean pushAgree;
+
+    @Column(nullable = true)
+    @Schema(description = "최근 로그인 시각", example = "2025-06-05T21:00:00")
+    private LocalDateTime loginDate;
+
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/user/entity/UserRole.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/user/entity/UserRole.java
@@ -1,0 +1,13 @@
+package com.kkimjinoh.movieadmin.domain.user.entity;
+
+/**
+ * 사용자 권한(Role) 구분 Enum
+ */
+public enum UserRole {
+    // 전체 권한
+    ROLE_ADMIN,
+    // 관리 권한
+    ROLE_MANAGER,
+    // 일부 권한
+    ROLE_OPERATOR
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/user/initializer/AdminInitializer.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/user/initializer/AdminInitializer.java
@@ -1,0 +1,62 @@
+package com.kkimjinoh.movieadmin.domain.user.initializer;
+
+import com.kkimjinoh.movieadmin.domain.user.entity.UserEntity;
+import com.kkimjinoh.movieadmin.domain.user.entity.UserRole;
+import com.kkimjinoh.movieadmin.domain.user.repository.UserRepository;
+import com.kkimjinoh.movieadmin.domain.userGroup.entity.UserGroupEntity;
+import com.kkimjinoh.movieadmin.domain.userGroup.repository.UserGroupRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AdminInitializer {
+
+    private final UserRepository userRepository;
+    private final UserGroupRepository userGroupRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final Environment env;
+
+    @PostConstruct
+    public void init() {
+
+        if (userRepository.existsByUserRole(UserRole.ROLE_ADMIN)) {
+            log.info("✅ 이미 ROLE_ADMIN 계정이 존재하므로 초기화 생략");
+            return;
+        }
+
+        String email = env.getProperty("init.admin.email");
+        String password = env.getProperty("init.admin.password");
+
+        if (email != null && password != null) {
+
+            // 기본 그룹을 조회 또는 생성
+            UserGroupEntity adminGroup = userGroupRepository.findById(1L)
+                    .orElseGet(() -> userGroupRepository.save(
+                            UserGroupEntity.builder()
+                                    .name("관리자 그룹")
+                                    .build()
+                    ));
+
+            UserEntity admin = UserEntity.builder()
+                    .email(email)
+                    .password(passwordEncoder.encode(password))
+                    .name("관리자")
+                    .userRole(UserRole.ROLE_ADMIN)
+                    .privacyAgree(true)
+                    .pushAgree(true)
+                    .userGroupEntity(adminGroup)
+                    .build();
+
+            userRepository.save(admin);
+            log.info("✅ 최초 관리자 계정 생성 완료: {}", email);
+        } else {
+            log.warn("❗ 관리자 계정 생성을 위한 환경변수가 설정되지 않았습니다.");
+        }
+    }
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/user/mapper/UserMapper.java
@@ -1,0 +1,74 @@
+package com.kkimjinoh.movieadmin.domain.user.mapper;
+
+import com.kkimjinoh.movieadmin.domain.user.dto.request.RequestUpdateMyInfoDto;
+import com.kkimjinoh.movieadmin.domain.user.dto.request.RequestUpdateUserDto;
+import com.kkimjinoh.movieadmin.domain.user.dto.response.ResponseGetUserDetailDto;
+import com.kkimjinoh.movieadmin.domain.user.dto.response.ResponseGetUserDto;
+import com.kkimjinoh.movieadmin.domain.user.entity.UserEntity;
+import com.kkimjinoh.movieadmin.domain.userGroup.entity.UserGroupEntity;
+import org.mapstruct.*;
+
+import java.util.List;
+
+/**
+ * 사용자 Mapper
+ */
+@Mapper(componentModel = "spring")
+public interface UserMapper {
+
+    /**
+     * UserEntity → ResponseGetUserDto 변환
+     */
+    @Mapping(source = "userGroupEntity.id", target = "userGroupId")
+    ResponseGetUserDto userEntityToResponseGetUserDto(UserEntity userEntity);
+
+
+    /**
+     * List<UserEntity> → List<ResponseGetUserDto> 변환
+     */
+    List<ResponseGetUserDto> userEntitiesToResUserDtos(List<UserEntity> userEntities);
+
+    /**
+     * List<UserEntity> → List<ResponseGetUserDetailDto> 변환
+     */
+    List<ResponseGetUserDetailDto> userEntitiesToResUserDetailDtos(List<UserEntity> userEntities);
+
+    /**
+     * UserEntity → ResponseGetUserDetailDto 변환
+     */
+    @Mapping(source = "userGroupEntity.id", target = "userGroupId")
+    ResponseGetUserDetailDto userEntityToResGetUserDetailDto(UserEntity userEntity);
+
+    /**
+     * RequestUpdateMyInfoDto → UserEntity 변환
+     */
+    default UserEntity reqUpdateMyInfoDtoToUserEntity(RequestUpdateMyInfoDto requestUpdateMyInfoDto, UserEntity user) {
+        return user.toBuilder()
+                .userGroupEntity(UserGroupEntity.builder()
+                        .id(requestUpdateMyInfoDto.getUserGroupId())
+                        .build())
+                .name(requestUpdateMyInfoDto.getName())
+                .phoneNumber(requestUpdateMyInfoDto.getPhoneNumber())
+                .studentNumber(requestUpdateMyInfoDto.getStudentNumber())
+                .privacyAgree(requestUpdateMyInfoDto.isPrivacyAgree())
+                .pushAgree(requestUpdateMyInfoDto.isPushAgree())
+                .build();
+    }
+
+    /**
+     * RequestUpdateUserDto → UserEntity 변환
+     */
+    default UserEntity reqUpdateUserDtoToUserEntity(RequestUpdateUserDto requestUpdateUserDto, UserEntity user) {
+        return user.toBuilder()
+                .userRole(requestUpdateUserDto.getUserRole())
+                .userGroupEntity(UserGroupEntity.builder()
+                        .id(requestUpdateUserDto.getUserGroupId())
+                        .build())
+                .name(requestUpdateUserDto.getName())
+                .phoneNumber(requestUpdateUserDto.getPhoneNumber())
+                .studentNumber(requestUpdateUserDto.getStudentNumber())
+                .privacyAgree(requestUpdateUserDto.isPrivacyAgree())
+                .pushAgree(requestUpdateUserDto.isPushAgree())
+                .build();
+    }
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/user/repository/UserRepository.java
@@ -1,12 +1,25 @@
 package com.kkimjinoh.movieadmin.domain.user.repository;
 
 import com.kkimjinoh.movieadmin.domain.user.entity.UserEntity;
+import com.kkimjinoh.movieadmin.domain.user.entity.UserRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 /**
  * 사용자 Repository
  */
 @Repository
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
+    /**
+     * 이메일로 사용자 조회
+     */
+    Optional<UserEntity> findByEmail(String email);
+
+
+    /**
+     * 특정 역할(Role)을 가진 사용자가 하나라도 존재하는지 확인
+     */
+    boolean existsByUserRole(UserRole userRole);
 }

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/user/service/AdminUserService.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/user/service/AdminUserService.java
@@ -1,0 +1,90 @@
+package com.kkimjinoh.movieadmin.domain.user.service;
+
+import com.kkimjinoh.global.dto.StatusOkResponseDto;
+import com.kkimjinoh.global.error.DomainError;
+import com.kkimjinoh.global.exception.DomainException;
+import com.kkimjinoh.movieadmin.domain.user.dto.request.RequestUpdateUserDto;
+import com.kkimjinoh.movieadmin.domain.user.dto.response.ResponseGetUserDetailDto;
+import com.kkimjinoh.movieadmin.domain.user.entity.UserEntity;
+import com.kkimjinoh.movieadmin.domain.user.mapper.UserMapper;
+import com.kkimjinoh.movieadmin.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+/**
+ * 사용자 관련 비즈니스 로직을 처리하는 Service (Admin 전용)
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminUserService {
+
+    private final UserMapper userMapper;
+    private final UserRepository userRepository;
+
+
+    /**
+     * 사용자들의 상세 정보를 조회한다.
+     *
+     * @return List<ResponseGetUserDetailDto> 사용자들의 상세 정보 응답 DTO
+     */
+    @Transactional(readOnly = true)
+    public List<ResponseGetUserDetailDto> getUserDetailList() {
+        List<UserEntity> users = userRepository.findAll();
+
+        // 사용자 데이터가 존재하지 않으면 예외 발생
+        if (users.isEmpty()) {
+            throw new DomainException(DomainError.USER_NOT_FOUND);
+        }
+
+        // List<UserEntity> → List<ResponseGetUserDetailDto> 변환
+        return userMapper.userEntitiesToResUserDetailDtos(users);
+    }
+
+
+    /**
+     * 특정 사용자의 정보를 수정한다.
+     *
+     * @param id 사용자 ID
+     * @param body 수정 요청 DTO
+     * @return ResponseGetUserDetailDto 수정된 사용자 상세 응답 DTO
+     */
+    @Transactional
+    public ResponseGetUserDetailDto updateUser(Long id, RequestUpdateUserDto body) {
+
+        // 1. 사용자 존재 여부 확인
+        UserEntity user = userRepository.findById(id)
+                .orElseThrow(() -> new DomainException(DomainError.USER_NOT_FOUND));
+
+        // RequestUpdateUserDto → UserEntity 변환
+        user = userMapper.reqUpdateUserDtoToUserEntity(body, user);
+        userRepository.save(user);
+
+        // UserEntity → ResponseGetUserDetailDto 변환
+        return userMapper.userEntityToResGetUserDetailDto(user);
+    }
+
+    /**
+     * 특정 사용자를 삭제한다.
+     *
+     * @param id 삭제할 사용자 ID
+     * @return StatusOkResponseDto 수정된 사용자 상세 응답 DTO
+     */
+    @Transactional
+    public StatusOkResponseDto deleteUser(Long id) {
+        // 1. 사용자 존재 여부 확인
+        UserEntity user = userRepository.findById(id)
+                .orElseThrow(() -> new DomainException(DomainError.USER_NOT_FOUND));
+
+        // soft 삭제
+        user.softDelete();
+
+        // OK 응답 반환
+        return new StatusOkResponseDto();
+    }
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/user/service/UserService.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/user/service/UserService.java
@@ -1,0 +1,111 @@
+package com.kkimjinoh.movieadmin.domain.user.service;
+
+import com.kkimjinoh.global.dto.StatusOkResponseDto;
+import com.kkimjinoh.global.error.DomainError;
+import com.kkimjinoh.global.exception.DomainException;
+import com.kkimjinoh.movieadmin.domain.user.dto.request.RequestUpdateMyInfoDto;
+import com.kkimjinoh.movieadmin.domain.user.dto.response.ResponseGetUserDetailDto;
+import com.kkimjinoh.movieadmin.domain.user.dto.response.ResponseGetUserDto;
+import com.kkimjinoh.movieadmin.domain.user.entity.UserEntity;
+import com.kkimjinoh.movieadmin.domain.user.mapper.UserMapper;
+import com.kkimjinoh.movieadmin.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+/**
+ * 사용자 관련 비즈니스 로직을 처리하는 Service
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserMapper userMapper;
+    private final UserRepository userRepository;
+
+    /**
+     * 사용자들의 정보를 조회한다.
+     *
+     * @return List<ResponseGetUserDto> 사용자들의 정보 응답 DTO
+     */
+    @Transactional(readOnly = true)
+    public List<ResponseGetUserDto> getUserList() {
+        List<UserEntity> users = userRepository.findAll();
+
+        // 사용자 데이터가 존재하지 않으면 예외 발생
+        if (users.isEmpty()) {
+            throw new DomainException(DomainError.USER_NOT_FOUND);
+        }
+
+        // List<UserEntity> → List<ResponseGetUserDto> 변환
+        return userMapper.userEntitiesToResUserDtos(users);
+    }
+
+
+    /**
+     * 현재 로그인한 사용자의 정보를 조회한다.
+     *
+     * @return ResponseGetUserDetailDto 로그인된 사용자 정보 응답 DTO
+     */
+    @Transactional(readOnly = true)
+    public ResponseGetUserDetailDto getMyInfo() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+
+        // 이메일로 사용자 조회, 없으면 예외
+        UserEntity user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new DomainException(DomainError.USER_NOT_FOUND));
+
+        // UserEntity → ResponseGetUserDetailDto 변환
+        return userMapper.userEntityToResGetUserDetailDto(user);
+    }
+
+    /**
+     * 현재 로그인한 사용자의 정보를 수정한다.
+     *
+     * @param body 사용자 정보 수정 요청 DTO
+     * @return ResponseGetUserDetailDto 수정된 사용자 정보 응답 DTO
+     */
+    @Transactional
+    public ResponseGetUserDetailDto updateMyInfo(RequestUpdateMyInfoDto body) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+
+        // 이메일로 사용자 조회, 없으면 예외
+        UserEntity user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new DomainException(DomainError.USER_NOT_FOUND));
+
+        // RequestUpdateMyInfoDto → UserEntity 변환
+        user = userMapper.reqUpdateMyInfoDtoToUserEntity(body, user);
+        userRepository.save(user);
+
+        // UserEntity → ResponseGetUserDetailDto 변환
+        return userMapper.userEntityToResGetUserDetailDto(user);
+    }
+
+    /**
+     * 현재 로그인한 사용자를 탈퇴 처리한다 (Soft Delete).
+     */
+    @Transactional
+    public StatusOkResponseDto deleteMyAccount() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+
+        // 이메일로 사용자 조회, 없으면 예외
+        UserEntity user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new DomainException(DomainError.USER_NOT_FOUND));
+
+        // soft 삭제
+        user.softDelete();
+
+        // OK 응답 반환
+        return new StatusOkResponseDto();
+    }
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/userGroup/controller/AdminUserGroupController.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/userGroup/controller/AdminUserGroupController.java
@@ -1,0 +1,55 @@
+package com.kkimjinoh.movieadmin.domain.userGroup.controller;
+
+import com.kkimjinoh.global.dto.StatusOkResponseDto;
+import com.kkimjinoh.movieadmin.domain.userGroup.docs.CreateUserGroupDoc;
+import com.kkimjinoh.movieadmin.domain.userGroup.docs.DeleteUserGroupDoc;
+import com.kkimjinoh.movieadmin.domain.userGroup.docs.UpdateUserGroupDoc;
+import com.kkimjinoh.movieadmin.domain.userGroup.dto.request.RequestCreateUserGroupDto;
+import com.kkimjinoh.movieadmin.domain.userGroup.dto.request.RequestUpdateUserGroupDto;
+import com.kkimjinoh.movieadmin.domain.userGroup.dto.response.ResponseGetUserGroupDto;
+import com.kkimjinoh.movieadmin.domain.userGroup.service.UserGroupService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+
+/**
+ * 사용자 그룹 Controller
+ * 사용자 그룹 생성, 조회, 수정, 삭제 기능을 담당한다.
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/user-group")
+@Tag(name = "사용자 그룹", description = "사용자 그룹 관리 기능")
+public class AdminUserGroupController {
+
+    private final UserGroupService userGroupService;
+
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping
+    @CreateUserGroupDoc
+    public ResponseEntity<ResponseGetUserGroupDto> createMessage(
+            @Valid @RequestBody RequestCreateUserGroupDto body) {
+        return ResponseEntity.ok(userGroupService.createUserGroup(body));
+    }
+
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("/{id}")
+    @UpdateUserGroupDoc
+    public ResponseEntity<ResponseGetUserGroupDto> updateUserGroup(
+            @PathVariable("id") Long id,
+            @Valid @RequestBody RequestUpdateUserGroupDto body) {
+        return ResponseEntity.ok(userGroupService.updateUserGroup(id, body));
+    }
+
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("/{id}")
+    @DeleteUserGroupDoc
+    public ResponseEntity<StatusOkResponseDto> deleteUserGroup(
+            @PathVariable("id") Long id) {
+        return ResponseEntity.ok(userGroupService.deleteUserGroup(id));
+    }
+}

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/userGroup/controller/UserGroupController.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/userGroup/controller/UserGroupController.java
@@ -1,16 +1,9 @@
 package com.kkimjinoh.movieadmin.domain.userGroup.controller;
 
-import com.kkimjinoh.global.dto.StatusOkResponseDto;
-import com.kkimjinoh.movieadmin.domain.userGroup.docs.CreateUserGroupDoc;
-import com.kkimjinoh.movieadmin.domain.userGroup.docs.DeleteUserGroupDoc;
 import com.kkimjinoh.movieadmin.domain.userGroup.docs.GetUserGroupListDoc;
-import com.kkimjinoh.movieadmin.domain.userGroup.docs.UpdateUserGroupDoc;
-import com.kkimjinoh.movieadmin.domain.userGroup.dto.request.RequestCreateUserGroupDto;
-import com.kkimjinoh.movieadmin.domain.userGroup.dto.request.RequestUpdateUserGroupDto;
 import com.kkimjinoh.movieadmin.domain.userGroup.dto.response.ResponseGetUserGroupDto;
 import com.kkimjinoh.movieadmin.domain.userGroup.service.UserGroupService;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,7 +16,7 @@ import java.util.List;
  */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/admin/user-group")
+@RequestMapping("/api/manager/user-group")
 @Tag(name = "사용자 그룹", description = "사용자 그룹 관리 기능")
 public class UserGroupController {
 
@@ -33,27 +26,5 @@ public class UserGroupController {
     @GetUserGroupListDoc
     public ResponseEntity<List<ResponseGetUserGroupDto>> getUserGroupList() {
         return ResponseEntity.ok(userGroupService.getUserGroupList());
-    }
-
-    @PostMapping
-    @CreateUserGroupDoc
-    public ResponseEntity<ResponseGetUserGroupDto> createMessage(
-            @Valid @RequestBody RequestCreateUserGroupDto body) {
-        return ResponseEntity.ok(userGroupService.createUserGroup(body));
-    }
-
-    @PutMapping("/{id}")
-    @UpdateUserGroupDoc
-    public ResponseEntity<ResponseGetUserGroupDto> updateUserGroup(
-            @PathVariable("id") Long id,
-            @Valid @RequestBody RequestUpdateUserGroupDto body) {
-        return ResponseEntity.ok(userGroupService.updateUserGroup(id, body));
-    }
-
-    @DeleteMapping("/{id}")
-    @DeleteUserGroupDoc
-    public ResponseEntity<StatusOkResponseDto> deleteUserGroup(
-            @PathVariable("id") Long id) {
-        return ResponseEntity.ok(userGroupService.deleteUserGroup(id));
     }
 }

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/userGroup/docs/CreateUserGroupDoc.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/userGroup/docs/CreateUserGroupDoc.java
@@ -21,8 +21,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Documented
 @Operation(
-        summary = "사용자 그룹 생성",
-        description = "새로운 공지사항을 등록한다."
+        summary = "\uD83D\uDD11 사용자 그룹 생성",
+        description = "Admin(관리자) 권한을 가진 사용자가 새로운 사용자 그룹 생성한다."
 )
 @RequestBody(
         required = true,

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/userGroup/docs/DeleteUserGroupDoc.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/userGroup/docs/DeleteUserGroupDoc.java
@@ -19,8 +19,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Documented
 @Operation(
-        summary = "사용자 그룹 삭제",
-        description = "특정 ID의 사용자 그룹을 삭제한다."
+        summary = "\uD83D\uDD11 사용자 그룹 삭제",
+        description = "Admin(관리자) 권한을 가진 사용자가 특정 ID의 사용자 그룹을 삭제한다."
 )
 @Parameter(
         name = "id",

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/userGroup/entity/UserGroupEntity.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/userGroup/entity/UserGroupEntity.java
@@ -1,20 +1,16 @@
 package com.kkimjinoh.movieadmin.domain.userGroup.entity;
 
 import com.kkimjinoh.global.entity.DateEntity;
-import com.kkimjinoh.movieadmin.domain.userGroup.dto.request.RequestUpdateUserGroupDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "user_group")
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
-@SuperBuilder
-@ToString
+@SuperBuilder(toBuilder = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_group")
 public class UserGroupEntity extends DateEntity {
 
     @Id

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/userGroup/mapper/UserGroupMapper.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/userGroup/mapper/UserGroupMapper.java
@@ -5,30 +5,35 @@ import com.kkimjinoh.movieadmin.domain.userGroup.dto.request.RequestUpdateUserGr
 import com.kkimjinoh.movieadmin.domain.userGroup.dto.response.ResponseGetUserGroupDto;
 import com.kkimjinoh.movieadmin.domain.userGroup.entity.UserGroupEntity;
 import org.mapstruct.Mapper;
-import org.mapstruct.MappingTarget;
 import java.util.List;
 
+/**
+ * 사용자 그룹 Mapper
+ */
 @Mapper(componentModel = "spring")
 public interface UserGroupMapper {
 
     /**
      * RequestCreateUserGroupDto → UserGroupEntity 변환
      */
-    UserGroupEntity requestCreateDtoToEntity(RequestCreateUserGroupDto requestCreateUserGroupDto);
+    UserGroupEntity reqCreateDtoToUserGroupEntity(RequestCreateUserGroupDto requestCreateUserGroupDto);
 
     /**
-     * RequestUpdateUserGroupDto → 기존 UserGroupEntity 병합
+     * RequestUpdateUserGroupDto → UserGroupEntity 변환
      */
-    void updateEntityFromRequestUpdateDto(RequestUpdateUserGroupDto requestUpdateUserGroupDto, @MappingTarget UserGroupEntity entity);
-
+    default UserGroupEntity reqUpdateDtoToUserGroupEntity(RequestUpdateUserGroupDto requestUpdateUserGroupDto, UserGroupEntity userGroupEntity) {
+        return userGroupEntity.toBuilder()
+                .name(requestUpdateUserGroupDto.getName())
+                .build();
+    }
     /**
      * UserGroupEntity → ResponseGetUserGroupDto 변환
      */
-    ResponseGetUserGroupDto entityToResponseDto(UserGroupEntity userGroupEntity);
+    ResponseGetUserGroupDto UserGroupEntityToResGetUserDto(UserGroupEntity userGroupEntity);
 
     /**
      * List<UserGroupEntity> → List<ResponseGetUserGroupDto> 변환
      */
-    List<ResponseGetUserGroupDto> entityToResponseDtoList(List<UserGroupEntity> userGroupEntities);
+    List<ResponseGetUserGroupDto> UserGroupEntitiesToResGetUserDtos(List<UserGroupEntity> userGroupEntities);
 
 }

--- a/src/main/java/com/kkimjinoh/movieadmin/domain/userGroup/service/UserGroupService.java
+++ b/src/main/java/com/kkimjinoh/movieadmin/domain/userGroup/service/UserGroupService.java
@@ -23,8 +23,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class UserGroupService {
 
-    private final UserGroupRepository userGroupRepository;
     private final UserGroupMapper userGroupMapper;
+    private final UserGroupRepository userGroupRepository;
 
 
     /**
@@ -35,7 +35,14 @@ public class UserGroupService {
     @Transactional(readOnly = true)
     public List<ResponseGetUserGroupDto> getUserGroupList() {
         List<UserGroupEntity> entities = userGroupRepository.findAll();
-        return userGroupMapper.entityToResponseDtoList(entities);
+
+        // 사용자 그룹이 없을 경우 예외 발생
+        if (entities.isEmpty()) {
+            throw new DomainException(DomainError.USER_GROUP_NOT_FOUND);
+        }
+
+        // List<UserGroupEntity> → List<ResponseGetUserGroupDto> 변환
+        return userGroupMapper.UserGroupEntitiesToResGetUserDtos(entities);
     }
 
     /**
@@ -46,9 +53,13 @@ public class UserGroupService {
      */
     @Transactional
     public ResponseGetUserGroupDto createUserGroup(RequestCreateUserGroupDto body) {
-        UserGroupEntity entity = userGroupMapper.requestCreateDtoToEntity(body);
+
+        // RequestCreateUserGroupDto → UserGroupEntity 변환
+        UserGroupEntity entity = userGroupMapper.reqCreateDtoToUserGroupEntity(body);
         UserGroupEntity saved = userGroupRepository.save(entity);
-        return userGroupMapper.entityToResponseDto(saved);
+
+        // UserGroupEntity → ResponseGetUserGroupDto 변환
+        return userGroupMapper.UserGroupEntityToResGetUserDto(saved);
     }
 
     /**
@@ -59,12 +70,17 @@ public class UserGroupService {
      */
     @Transactional
     public ResponseGetUserGroupDto updateUserGroup(Long id, RequestUpdateUserGroupDto body) {
-        UserGroupEntity entity = userGroupRepository.findById(id)
+
+        // 사용자 그룹 조회 (없으면 예외 발생)
+        UserGroupEntity userGroup = userGroupRepository.findById(id)
                 .orElseThrow(() -> new DomainException(DomainError.USER_GROUP_NOT_FOUND));
 
-        userGroupMapper.updateEntityFromRequestUpdateDto(body, entity);
+        // RequestUpdateUserGroupDto → UserGroupEntity 변환
+        userGroup = userGroupMapper.reqUpdateDtoToUserGroupEntity(body, userGroup);
+        userGroupRepository.save(userGroup);
 
-        return userGroupMapper.entityToResponseDto(entity);
+        // UserGroupEntity → ResponseGetUserGroupDto 변환
+        return userGroupMapper.UserGroupEntityToResGetUserDto(userGroup);
     }
 
 
@@ -76,11 +92,14 @@ public class UserGroupService {
      */
     @Transactional
     public StatusOkResponseDto deleteUserGroup(Long id) {
-        // 엔티티 조회, 없으면 예외
-        UserGroupEntity entity = userGroupRepository.findById(id)
+
+        // 사용자 그룹 조회 (없으면 예외 발생)
+        userGroupRepository.findById(id)
                 .orElseThrow(() -> new DomainException(DomainError.USER_GROUP_NOT_FOUND));
 
         userGroupRepository.deleteById(id);
+
+        // OK 응답 반환
         return new StatusOkResponseDto();
     }
 }


### PR DESCRIPTION
## 사용자 초대 및 인증 기능 구현 요약

> Spring Security + JWT 기반 사용자 인증 시스템  
> 관리자에 의한 사용자 초대 → 인증 코드 발급 → 회원가입 완료 → 로그인 및 리프레시 토큰 발급 흐름을 완성하고  
> DTO ↔ Entity 매핑은 `MapStruct` 기반으로 리팩토링하여 유지보수성을 개선함

---

### ✔️ 실제 구현한 작업 목록

---

#### 📨 사용자 초대 흐름

- 관리자 계정이 `RequestInviteDto`를 통해 사용자를 초대
- `AuthMapper.reqInviteDtoToUserEntity()`를 통해 사용자 엔티티로 변환 및 저장
- `AuthCodeEntity` 생성:
  - 초대받은 사용자 이메일, 랜덤 인증코드, 유효기간, 생성자(관리자 ID)를 포함
  - `@Builder` 및 `@ManyToOne` 관계 설정으로 관리자 연동

---

#### 📮 인증 코드 발급 및 검증

- 사용자 이메일 + 인증코드로 `signupToken` JWT 생성
  - JWT 내부 Claims:
    - `purpose: signup`, `email`, `exp`
- 클라이언트가 해당 토큰을 통해 회원가입 페이지 접근 가능

---

#### 👤 회원가입 완료 처리

- `RequestRegisterDto`를 통해 이름, 학번, 비밀번호 등 정보 입력
- JWT 내부 이메일과 매칭되는 기존 `UserEntity`를 검색
- `AuthMapper.reqRegisterDtoToUserEntity()`에서 기존 Entity에 `toBuilder()`를 활용해 정보를 병합
  - 비밀번호는 `BCryptPasswordEncoder`로 암호화
- 최종적으로 완성된 Entity를 저장해 회원가입 완료

---

#### 🔐 로그인 및 토큰 발급

- 이메일 + 비밀번호로 로그인 요청 시:
  - 사용자 존재 여부 및 비밀번호 일치 여부 검증
- 로그인 성공 시:
  - `createAccessToken(user)` → 10분 만료 AccessToken 발급
  - `createRefreshToken(user)` → 7일 만료 RefreshToken 발급
- 두 토큰 모두 JWT에 `userId`, `role`, `purpose` 정보 삽입

---

#### 🔁 리프레시 토큰 재발급

- `/auth/reissue` 요청 시:
  - RefreshToken 유효성 검증 → 새로운 AccessToken 재발급
- `JwtTokenProvider.getAuthentication()` 통해 유저 권한 확인

---

### 🧱 MapStruct 기반 리팩토링

- `AuthMapper`, `UserMapper`에서 DTO ↔ Entity 매핑 로직 통일
- 사용자 정보 수정 및 가입 로직에서 `@MappingTarget`과 `toBuilder()`를 활용하여 깔끔하게 필드 병합
- 예시 메서드:
  ```java
  default UserEntity reqRegisterDtoToUserEntity(RequestRegisterDto dto, UserEntity entity, String encodedPassword) {
      return entity.toBuilder()
          .name(dto.getName())
          .password(encodedPassword)
          .studentNumber(dto.getStudentNumber())
          .phoneNumber(dto.getPhoneNumber())
          .privacyAgree(dto.isPrivacyAgree())
          .build();
  }
  ```

---

### 📦 환경 구성

- `application.yml`에 AWS Parameter Store 연동:
  ```yaml
  spring:
    config:
      import: optional:aws-parameterstore:/config/movieadmin/
  ```
- `jwt.secret`, `jwt.access-token-expiration`, `jwt.refresh-token-expiration`, `jwt.signup-token-expiration` 등 외부 환경변수로 분리 관리
- `JwtTokenProvider` 생성자에서 `@Value`로 주입받아 설정

---

### ✅ 정리

- 사용자의 전체 인증 사이클 (초대 → 인증코드 → 회원가입 → 로그인/리프레시 토큰) 완성
- 코드 불변성, 유지보수성, 테스트 용이성을 고려하여 `Builder`, `toBuilder`, `MapStruct` 기반으로 리팩토링 완료
